### PR TITLE
Original

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lib
 .DS_Store
+.vscode

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,46 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "起動",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceRoot}/ogpParser.js",
+      "stopOnEntry": false,
+      "args": [],
+      "cwd": "${workspaceRoot}",
+      "preLaunchTask": null,
+      "runtimeExecutable": null,
+      "runtimeArgs": [
+        "--nolazy"
+      ],
+      "env": {
+        "NODE_ENV": "development"
+      },
+      "externalConsole": false,
+      "sourceMaps": false,
+      "outDir": null
+    },
+    {
+      "name": "アタッチ",
+      "type": "node",
+      "request": "attach",
+      "port": 5858,
+      "address": "localhost",
+      "restart": false,
+      "sourceMaps": false,
+      "outDir": null,
+      "localRoot": "${workspaceRoot}",
+      "remoteRoot": null
+    },
+    {
+      "name": "Attach to Process",
+      "type": "node",
+      "request": "attach",
+      "processId": "${command.PickProcess}",
+      "port": 5858,
+      "sourceMaps": false,
+      "outDir": null
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,62 @@
 # Open Graph Protocol Parser
-このモジュールは，ukyoda氏のogp-parser(https://github.com/ukyoda/ogpParser)のマイナーフィックスです。
-指定されたurlがutf-8,ascii以外の文字コードを指定している場合、自動変換してからogpを取得します。
-その他の機能はogp-parserと同一です。
-ogp-parserにpull requestがmergeされたらnpmを削除します。
+このモジュールは，URLからOGPタグ情報、SEO関連のタグ情報などを抽出する為のライブラリです。
+
+## 更新履歴
+* 2014年 6月: seoタグ(name, contentのメタタグ)を追加
+* 2014年 6月: データフォーマットを修正
+* 2015年 3月: ページタイトル情報を追加
+* 2015年 3月: https対応
+* 2015年 4月: リダイレクトに対応しました。第３引数をtrueにすると、リダイレクトを追跡してページを取得します
+* 2015年 5月: ver0.3.0リリース
+
+## 依存ライブラリ
+* cheerio
+* follow-redirects (新規)
+* jsChardet
+* iconv-lite
+
+## 使い方
+```
+    var ogp = require('ogp-parser');
+```
+
+## サンプル (リダイレクトあり)
+```javascript
+    var ogp = require("ogp-parser");
+    var url = "http://ogp.me";
+    ogp.parser(url,function(error,data){
+	console.log(data);
+    }, true);
+```
+
+## サンプル (リダイレクトなし)
+```javascript
+    var ogp = require("ogp-parser");
+    var url = "http://ogp.me";
+    ogp.parser(url,function(error,data){
+	console.log(data);
+    }, false);
+```
+
+## 出力
+```javascript
+
+{ title: 'The Open Graph protocol',
+  ogp: 
+   [ 'og:title': [ 'Open Graph protocol' ],
+     'og:type': [ 'website' ],
+     'og:url': [ 'http://ogp.me/' ],
+     'og:image': [ 'http://ogp.me/logo.png' ],
+     'og:image:type': [ 'image/png' ],
+     'og:image:width': [ '300' ],
+     'og:image:height': [ '300' ],
+     'og:description': [ 'The Open Graph protocol enables any web page to become a rich object in a social graph.' ],
+     'fb:app_id': [ '115190258555800' ] ],
+  seo: [ description: [ 'The Open Graph protocol enables any web page to become a rich object in a social graph.' ] ] }
+
+```
 
 ## 免責事項など
-* BSDライセンスが適用されます。
-* ライブラリの利用は特に制限を設けません、
+* ライブラリの利用は特に制限を設けません
+* このライブラリは作者の勉強用に作成したため，今後のサポートは基本的に考えておりません。
 

--- a/README.md
+++ b/README.md
@@ -1,59 +1,9 @@
 # Open Graph Protocol Parser
-このモジュールは，URLからOGPタグ情報、SEO関連のタグ情報などを抽出する為のライブラリです。
-
-## 更新履歴
-* 2014年 6月: seoタグ(name, contentのメタタグ)を追加
-* 2014年 6月: データフォーマットを修正
-* 2015年 3月: ページタイトル情報を追加
-* 2015年 3月: https対応
-* 2015年 4月: リダイレクトに対応しました。第３引数をtrueにすると、リダイレクトを追跡してページを取得します
-* 2015年 5月: ver0.3.0リリース
-
-## 依存ライブラリ
-* cheerio
-* follow-redirects (新規)
-
-## 使い方
-```
-    var ogp = require('ogp-parser');
-```
-
-## サンプル (リダイレクトあり)
-```javascript
-    var ogp = require("ogp-parser");
-    var url = "http://ogp.me";
-    ogp.parser(url,function(error,data){
-	console.log(data);
-    }, true);
-```
-
-## サンプル (リダイレクトなし)
-```javascript
-    var ogp = require("ogp-parser");
-    var url = "http://ogp.me";
-    ogp.parser(url,function(error,data){
-	console.log(data);
-    }, false);
-```
-
-## 出力
-```javascript
-
-{ title: 'The Open Graph protocol',
-  ogp: 
-   [ 'og:title': [ 'Open Graph protocol' ],
-     'og:type': [ 'website' ],
-     'og:url': [ 'http://ogp.me/' ],
-     'og:image': [ 'http://ogp.me/logo.png' ],
-     'og:image:type': [ 'image/png' ],
-     'og:image:width': [ '300' ],
-     'og:image:height': [ '300' ],
-     'og:description': [ 'The Open Graph protocol enables any web page to become a rich object in a social graph.' ],
-     'fb:app_id': [ '115190258555800' ] ],
-  seo: [ description: [ 'The Open Graph protocol enables any web page to become a rich object in a social graph.' ] ] }
-
-```
+このモジュールは，ukyoda氏のogp-parser(https://github.com/ukyoda/ogpParser)のマイナーフィックスです。
+指定されたurlがutf-8,ascii以外の文字コードを指定している場合、自動変換してからogpを取得します。
+その他の機能はogp-parserと同一です。
 
 ## 免責事項など
-* ライブラリの利用は特に制限を設けません
-* このライブラリは作者の勉強用に作成したため，今後のサポートは基本的に考えておりません。
+* BSDライセンスが適用されます。
+* ライブラリの利用は特に制限を設けません、
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 このモジュールは，ukyoda氏のogp-parser(https://github.com/ukyoda/ogpParser)のマイナーフィックスです。
 指定されたurlがutf-8,ascii以外の文字コードを指定している場合、自動変換してからogpを取得します。
 その他の機能はogp-parserと同一です。
+ogp-parserにpull requestがmergeされたらnpmを削除します。
 
 ## 免責事項など
 * BSDライセンスが適用されます。

--- a/ogpParser.js
+++ b/ogpParser.js
@@ -3,12 +3,13 @@
  * @author ukyoda
  */
 
-
+// @str : encoded string
+// @encoding ; encoding character code string 
 var convertCharset = function(str,encoding){
 	var iconv = require("iconv-lite");
 	return iconv.decode(str,encoding);
 }
-
+//@str : encoded string
 var charsetConverter = function(str){
 	var jschardet = require("jschardet");
 	var detected = jschardet.detect(str);
@@ -97,7 +98,3 @@ var ogpParser = function($metaObject){
 		content: content
 	};
 };
-
-var additionalParser = function($metaObject){
-	
-}

--- a/ogpParser.js
+++ b/ogpParser.js
@@ -2,7 +2,13 @@
  * @fileOverview OpenGraph Protocol Parser
  * @author ukyoda
  */
-
+var charsetConverter = function(str){
+	var jschardet = require("jschardet");
+	var iconv = require("iconv-lite");
+	var detected = jschardet.detect(str);
+	if(detected.encoding != "utf8" && detected.encoding != "ascii")
+		return iconv.decode(str,detected.encoding);
+}
 
 var cheerio = require('cheerio')
  , $
@@ -19,10 +25,12 @@ exports.parser = function(url, callback, redirectFlg){
 	    httpRequest = (url.indexOf('https://') !== -1)? https : http;
 	}
 	httpRequest.get(url, function(res){
+		var chunks = [];
 		res.on('data', function(data){
-			html += data.toString();
+			chunks.push(data);
 		});
 		res.on('end', function(){
+			var html = charsetConverter(Buffer.concat(chunks));
 			var ogps = onDataCallBack.call(this,url, html);
 			callback(null, ogps);
 		});
@@ -83,4 +91,3 @@ var ogpParser = function($metaObject){
 		content: content
 	};
 };
-

--- a/ogpParser.js
+++ b/ogpParser.js
@@ -2,12 +2,18 @@
  * @fileOverview OpenGraph Protocol Parser
  * @author ukyoda
  */
+
+
+var convertCharset = function(str,encoding){
+	var iconv = require("iconv-lite");
+	return iconv.decode(str,encoding);
+}
+
 var charsetConverter = function(str){
 	var jschardet = require("jschardet");
-	var iconv = require("iconv-lite");
 	var detected = jschardet.detect(str);
 	if(detected.encoding != "utf8" && detected.encoding != "ascii")
-		return iconv.decode(str,detected.encoding);
+		return convertCharset(str,detected.encoding);
 }
 
 var cheerio = require('cheerio')
@@ -91,3 +97,7 @@ var ogpParser = function($metaObject){
 		content: content
 	};
 };
+
+var additionalParser = function($metaObject){
+	
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ogp-parser",
-  "version": "0.3.0",
+  "name": "ogp-parser-decode",
+  "version": "0.1.0",
   "private": false,
   "dependencies": {
     "cheerio": "~0.17.0",
@@ -10,8 +10,7 @@
     "jschardet":"1.4.1"
   },
   "readmeFilename": "README.md",
-  "gitHead": "db4f225533c56360ea9f61d759184e9fbe2b4dea",
-  "description": "This Package is Open Graph Parser.",
+  "description": "This Package is Open Graph Parser with AutoDecoding",
   "main": "ogpParser.js",
   "devDependencies": {},
   "scripts": {
@@ -19,13 +18,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ukyoda/ogpParser.git"
+    "url": "https://github.com/nemu626/ogpParser"
   },
   "keywords": [
     "ogp",
     "OpenGraphProtocol"
   ],
-  "author": "ukyoda",
+  "author": "nemu626",
   "license": "BSD",
   "directories": {
     "example": "example"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ogp-parser-decode",
-  "version": "0.1.0",
+  "name": "ogp-parser",
+  "version": "0.3.0",
   "private": false,
   "dependencies": {
     "cheerio": "~0.17.0",
@@ -10,7 +10,8 @@
     "jschardet":"1.4.1"
   },
   "readmeFilename": "README.md",
-  "description": "This Package is Open Graph Parser with AutoDecoding",
+  "gitHead": "db4f225533c56360ea9f61d759184e9fbe2b4dea",
+  "description": "This Package is Open Graph Parser.",
   "main": "ogpParser.js",
   "devDependencies": {},
   "scripts": {
@@ -18,13 +19,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/nemu626/ogpParser"
+    "url": "https://github.com/ukyoda/ogpParser.git"
   },
   "keywords": [
     "ogp",
     "OpenGraphProtocol"
   ],
-  "author": "nemu626",
+  "author": "ukyoda",
   "license": "BSD",
   "directories": {
     "example": "example"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "dependencies": {
     "cheerio": "~0.17.0",
     "follow-redirects": "0.0.3",
-    "jQuery": "~1.7.4"
+    "jQuery": "~1.7.4",
+    "iconv-lite": "0.4.13",
+    "jschardet":"1.4.1"
   },
   "readmeFilename": "README.md",
   "gitHead": "db4f225533c56360ea9f61d759184e9fbe2b4dea",


### PR DESCRIPTION
取ってきたhtmlがutf8やascii以外の文字コードの場合、文字化けしたままogpを取ってくるバグがあったので、jschardetで文字コードを認識し、iconv-liteで文字コードを変換する機能を追加しました。