### PR TITLE
catch decode error

### DIFF
--- a/utils/charsetConverter.js
+++ b/utils/charsetConverter.js
@@ -7,13 +7,17 @@ const iconv = require('iconv-lite'),
 
 /**
  * 文字コードをUTF-8に変換する
- * @param {string} str 文字列
- * @return {string} UTF-8に変換された文字列
+ * @param {string|Buffer} str 文字列
+ * @return {string|Buffer} UTF-8に変換された文字列
  */
 module.exports = function charsetConverter(str) {
 	var detected = jschardet.detect(str); // 文字コードを取得
 	if(detected.encoding != "utf8" && detected.encoding != "ascii" && detected.encoding != 'ISO-8859-2'){
-		return iconv.decode(str, detected.encoding);
+		try {
+			return iconv.decode(str, detected.encoding);
+		} catch(e) {
+			return str;
+		}
 	} else {
 		return str;
 	}


### PR DESCRIPTION
```js
iconv.decode(Buffer.concat([]), detected.encoding);
```

のとき、以下のエラーが起きてしまう。 `charsetConverter ` を使用している `getContents` では handle できていないので、Promise は reject も resolve もせずに、プロセスが死んでしまうケースがありました。

```
Error: Encoding not recognized: 'null' (searched as: 'null') at Object.getCodec (/node_modules/ogp-parser/node_modules/iconv-lite/lib/index.js:102:23) at Object.getDecoder (/node_modules/ogp-parser/node_modules/iconv-lite/lib/index.js:118:23) at Object.decode (/node_modules/ogp-parser/node_modules/iconv-lite/lib/index.js:36:25) at charsetConverter (/node_modules/ogp-parser/utils/charsetConverter.js:16:16) at IncomingMessage.<anonymous> (/node_modules/ogp-parser/utils/getContents.js:21:28) at IncomingMessage.emit (events.js:205:15) at IncomingMessage.EventEmitter.emit (domain.js:471:20) at endReadableNT (_stream_readable.js:1137:12) at processTicksAndRejections (internal/process/task_queues.js:84:9)
```

ので、error を handle してみました。